### PR TITLE
Increase tappable area for CrossOver selector

### DIFF
--- a/Crossover patcher/ContentView.swift
+++ b/Crossover patcher/ContentView.swift
@@ -52,7 +52,9 @@ struct ContentView: View {
                             .font(.title2)
                             .fontWeight(.bold)
                             .multilineTextAlignment(.center)
-                            .padding(20.0))
+                            .padding(20.0)
+                        )
+                        .contentShape(RoundedRectangle(cornerRadius: 25))
                         .onTapGesture {
                             if let url = openAppSelectorPanel() {
                                 restoreAndPatch(repatch: repatch, url: url, status: &status, externalUrl: externalUrl, skipVersionCheck: skipVersionCheck)


### PR DESCRIPTION
Right now you can only click on the text itself to select the CrossOver app. This patch increases clickable area and makes it equal to the drop area.