### PR TITLE
Correct Polish disclaimer confirmation.

### DIFF
--- a/Crossover patcher/pl.lproj/Localizable.strings
+++ b/Crossover patcher/pl.lproj/Localizable.strings
@@ -36,9 +36,9 @@ Jeśli napotkasz jakiekolwiek problemy z instalacją CrossOver, możesz pobrać 
 "RestoreSuccess" = "CrossOver.app został pomyślnie przywrócony.";
 "GcenxURL" = "https://github.com/Gcenx";
 "nastysURL" = "https://github.com/nastys";
-"MediaFoundation" = "Aby Media Foundation działały, musisz zainstalować GStreamer JEŚLI JUŻ TEGO NIE ZROBIŁEŚ (wymagana instalacja dla wszystkich użytkowników)";
+"MediaFoundation" = "Aby Media Foundation działały, musisz zainstalować GStreamer JEŚLI JESZCZE TEGO NIE ZROBIŁEŚ (wymagana instalacja dla wszystkich użytkowników)";
 "DownloadGStreamer" = "Pobieranie Gstreamer";
 "GStreamerInstalled" = "GStreamer jest już zainstalowany";
 "waitFor" = "Czekam na przeczytanie zastrzeżenia i potwierdzenie";
-"confirmationValue" = "Nie będę prosić Codeweavers o wsparcie ani zwrot pieniędzy";
-"confirmation" =  "Wpisz 'Nie poproszę Codeweavers o wsparcie ani o zwrot pieniędzy' w polu wejściowym poniżej";
+"confirmationValue" = "Nie będę prosić Codeweavers o pomoc techniczną ani zwrot pieniędzy";
+"confirmation" =  "Wpisz 'Nie będę prosić Codeweavers o pomoc techniczną ani zwrot pieniędzy' w polu wejściowym poniżej";


### PR DESCRIPTION
Fix grammar and confirmation text not matching what user is asked to type.

Jeszcze = Yet

Już = Already

Wsparcie = Support is a bit not clear so extended that, ~~considering end users are a bit dummies~~

Generally looks fine and sorry for overlooking it earlier unless it's not an issue to do re-release for this 5 people using localized macOS 😅 