### PR TITLE
Only show GStreamer install notice if not found

### DIFF
--- a/Crossover patcher/Selectors/AppSelector.swift
+++ b/Crossover patcher/Selectors/AppSelector.swift
@@ -47,19 +47,20 @@ struct AppSelector: View {
             }
             .padding(.top, 5.0)
         }
-        Text(localizedCXPatcherString(forKey: "MediaFoundation"))
-            .padding(.top, 6.0)
-            .frame(alignment: .center)
-        Link(localizedCXPatcherString(forKey: "DownloadGStreamer"), destination: URL(string: "https://gstreamer.freedesktop.org/data/pkg/osx/1.22.4/gstreamer-1.0-1.22.4-universal.pkg")!)
-            .padding(.top, 6.0)
-            .buttonStyle(.borderedProminent)
         
         if(isGStreamerInstalled()) {
             HStack(alignment: .center) {
                 Image(systemName: "checkmark.seal.fill").foregroundColor(.green)
                 Text(localizedCXPatcherString(forKey: "GStreamerInstalled"))
             }
-            .padding(.top, 6.0)
+            .padding(.top, 16.0)
+        } else {
+            Text(localizedCXPatcherString(forKey: "MediaFoundation"))
+                .padding(.top, 6.0)
+                .frame(alignment: .center)
+            Link(localizedCXPatcherString(forKey: "DownloadGStreamer"), destination: URL(string: "https://gstreamer.freedesktop.org/data/pkg/osx/1.22.4/gstreamer-1.0-1.22.4-universal.pkg")!)
+                .padding(.top, 6.0)
+                .buttonStyle(.borderedProminent)
         }
     }
 }

--- a/Crossover patcher/de.lproj/Localizable.strings
+++ b/Crossover patcher/de.lproj/Localizable.strings
@@ -36,7 +36,7 @@ Falls nach der Patch-Installation Probleme auftreten, können Sie eine neue Kopi
 "RestoreSuccess" = "CrossOver.app wurde erfolgreich wiederhergestellt.";
 "GcenxURL" = "https://github.com/Gcenx";
 "nastysURL" = "https://github.com/nastys";
-"MediaFoundation" = "Um die Media Foundation-Bibliotheken zum Laufen zu bringen, müssen Sie GStreamer installieren, SOFERN SIE ES NOCH NICHT GETAN HABEN (Installation für alle Benutzer erforderlich)";
+"MediaFoundation" = "Um die Media Foundation-Bibliotheken zum Laufen zu bringen, müssen Sie GStreamer installieren (Installation für alle Benutzer erforderlich)";
 "DownloadGStreamer" = "GStreamer herunterladen";
 "GStreamerInstalled" = "GStreamer ist bereits installiert";
 "waitFor" = "Bitte lesen Sie den Haftungsausschluss und bestätigen Sie";

--- a/Crossover patcher/en.lproj/Localizable.strings
+++ b/Crossover patcher/en.lproj/Localizable.strings
@@ -36,7 +36,7 @@ If you face any issues after your installation has been patched, you may downloa
 "RestoreSuccess" = "CrossOver.app has been successfully restored.";
 "GcenxURL" = "https://github.com/Gcenx";
 "nastysURL" = "https://github.com/nastys";
-"MediaFoundation" = "In order to make Media foundation libraries work you'll have to install GStreamer IF YOU HAVEN'T DONE IT ALREADY (Install for all users required)";
+"MediaFoundation" = "In order to make Media foundation libraries work you'll have to install GStreamer (Install for all users required)";
 "DownloadGStreamer" = "Download GStreamer";
 "GStreamerInstalled" = "GStreamer is already Installed";
 "waitFor" = "Waiting for you to read the disclaimer and confirm";


### PR DESCRIPTION
The GStreamer install notice and Download link, will only be shown if GStreamer is not installed.

Here are some screenshots.

![CleanShot 2023-07-16 at 11 31 38@2x](https://github.com/italomandara/CXPatcher/assets/2091312/1910f363-7442-4e4d-a024-a4dd5405d967)
![CleanShot 2023-07-16 at 11 29 55@2x](https://github.com/italomandara/CXPatcher/assets/2091312/86eb6a0c-7f3c-4d0d-a01b-ed71eb87833a)
