### PR TITLE
Translations

### DIFF
--- a/Crossover patcher.xcodeproj/project.pbxproj
+++ b/Crossover patcher.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Crossover-patcher-Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "CrossOver Patcher";
+				INFOPLIST_KEY_CFBundleDisplayName = CXPatcher;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -520,7 +520,7 @@
 				GCC_OPTIMIZATION_LEVEL = z;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Crossover-patcher-Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "CrossOver Patcher";
+				INFOPLIST_KEY_CFBundleDisplayName = CXPatcher;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Crossover patcher/en.lproj/Localizable.strings
+++ b/Crossover patcher/en.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Many thanks to the developers behind the DXVK and MoltenVK patches for their great help and for providing the binaries.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "CodeWeavers Downloads Page";
-"CrossOverPatcher" = "CrossOver Patcher";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "CodeWeavers forums";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
-"CWWebsite" = "Codeweavers doesn't support patched or modified crossover apps, see the";
-"CXPatcherName" = "CrossOver Patcher";
+"CWWebsite" = "CodeWeavers doesn't support patched or modified CrossOver apps, see the";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Please note:";
 "DisclaimerText" = "This is an unofficial patching program for CrossOver, and CodeWeavers is in no way involved in its development. Although it has been tested, this software may render your CrossOver installation unusable or unstable. USE AT YOUR OWN RISK. Use of this patcher will also void any official support from CodeWeavers.
 
@@ -31,7 +31,7 @@ If you face any issues after your installation has been patched, you may downloa
 "PatchStatusSuccess" = "CrossOver.app has been successfully patched";
 "RestoreButtonLabel" = "Restore";
 "RestoreConfirm" = "Cool!";
-"RestoreFailure" = "Either this CrossOver.app is unpatched, or was patched with an incompatible version of CrossOver Patcher.";
+"RestoreFailure" = "Either this CrossOver.app is unpatched, or was patched with an incompatible version of CXPatcher.";
 "RestoreStatusLabel" = "CrossOver.app Restore";
 "RestoreSuccess" = "CrossOver.app has been successfully restored.";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@ If you face any issues after your installation has been patched, you may downloa
 "DownloadGStreamer" = "Download GStreamer";
 "GStreamerInstalled" = "GStreamer is already Installed";
 "waitFor" = "Waiting for you to read the disclaimer and confirm";
-"confirmationValue" = "I will not ask Codeweavers for support or refund";
-"confirmation" =  "Please type 'I will not ask Codeweavers for support or refund' in the input field below";
+"confirmationValue" = "I will not ask CodeWeavers for support or refund";
+"confirmation" =  "Please type 'I will not ask CodeWeavers for support or refund' in the input field below";
 "unsupported" = "unsupported";

--- a/Crossover patcher/es.lproj/Localizable.strings
+++ b/Crossover patcher/es.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Muchas gracias a los desarrolladores que están detrás de los parches DXVK y MoltenVK por su gran ayuda y su proporción de los binarios.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "Página de descarga de CodeWeavers";
-"CrossOverPatcher" = "CrossOver Patcher";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "Foros de CodeWeavers";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
 "CWWebsite" = "CodeWeavers no ofrece soporte para versiones de su software parcheado o modificado. Ver";
-"CXPatcherName" = "CrossOver Patcher";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Ten en cuenta:";
 "DisclaimerText" = "Este software de parcheo no es oficial de CrossOver, por ende CodeWeavers no está involucrado en ningún ámbito del desarrollo. Aunque el software ha sido probado, puede generar que tu instalación de CrossOver se vuelva inutilizable o inestable. ÚSELO BAJO SU PROPIO RIESGO. El uso de éste parche anulará todo soporte oficial de CodeWeavers.
 

--- a/Crossover patcher/fr.lproj/Localizable.strings
+++ b/Crossover patcher/fr.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Un grand merci aux développeurs derrière les correctifs DXVK et MoltenVK pour leur précieuse aide et la fourniture des binaires.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "Page de téléchargements de CodeWeavers";
-"CrossOverPatcher" = "Patch CrossOver";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "Forums de CodeWeavers";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
 "CWWebsite" = "CodeWeavers ne prend pas en charge les applications CrossOver modifiées ou patchées, voir";
-"CXPatcherName" = "Patch CrossOver";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Veuillez noter :";
 "DisclaimerText" = "Il s'agit d'un programme de patch non officiel pour CrossOver, et CodeWeavers n'est en aucun cas impliqué dans son développement. Bien qu'il ait été testé, ce logiciel peut rendre votre installation de CrossOver inutilisable ou instable. UTILISEZ À VOS PROPRES RISQUES. L'utilisation de ce patch annulera également tout support officiel de la part de CodeWeavers.
 
@@ -31,7 +31,7 @@ Si vous rencontrez des problèmes après avoir appliqué le patch, vous pouvez t
 "PatchStatusSuccess" = "CrossOver.app a été correctement patchée";
 "RestoreButtonLabel" = "Restaurer";
 "RestoreConfirm" = "Bien !";
-"RestoreFailure" = "Soit cette CrossOver.app n'est pas patchée, soit elle a été patchée avec une version incompatible de CrossOver Patcher.";
+"RestoreFailure" = "Soit cette CrossOver.app n'est pas patchée, soit elle a été patchée avec une version incompatible de CXPatcher.";
 "RestoreStatusLabel" = "Restauration de CrossOver.app";
 "RestoreSuccess" = "CrossOver.app a été restaurée avec succès.";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@ Si vous rencontrez des problèmes après avoir appliqué le patch, vous pouvez t
 "DownloadGStreamer" = "Télécharger GStreamer";
 "GStreamerInstalled" = "GStreamer est déjà installé";
 "waitFor" = "En attente de votre lecture de la clause de non-responsabilité et de votre confirmation";
-"confirmationValue" = "Je ne demanderai pas de support ou de remboursement à Codeweavers";
-"confirmation" = "Veuillez taper 'Je ne demanderai pas de support ou de remboursement à Codeweavers' dans le champ de saisie ci-dessous";
+"confirmationValue" = "Je ne demanderai pas de support ou de remboursement à CodeWeavers";
+"confirmation" = "Veuillez taper 'Je ne demanderai pas de support ou de remboursement à CodeWeavers' dans le champ de saisie ci-dessous";
 "unsupported" = "non pris en charge";

--- a/Crossover patcher/it.lproj/Localizable.strings
+++ b/Crossover patcher/it.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Un grande ringraziamento agli sviluppatori dietro le patch DXVK e MoltenVK per il loro grande aiuto e per la fornitura delle librerie.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "Pagina dei download di CodeWeavers";
-"CrossOverPatcher" = "CrossOver Patcher";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "Forum di CodeWeavers";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
 "CWWebsite" = "CodeWeavers non supporta applicazioni CrossOver patchate o modificate, consulta il link:";
-"CXPatcherName" = "CrossOver Patcher";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Nota bene:";
 "DisclaimerText" = "Questo è un programma di patching non ufficiale per CrossOver, e CodeWeavers non è in alcun modo coinvolto nel suo sviluppo. Sebbene sia stato testato, questo software potrebbe rendere la tua installazione di CrossOver inutilizzabile o instabile. USALO A TUO RISCHIO. L'utilizzo di questo patcher annullerà anche qualsiasi supporto ufficiale da parte di CodeWeavers.
 
@@ -31,7 +31,7 @@ Se incontri problemi dopo aver patchato la tua installazione, puoi scaricare una
 "PatchStatusSuccess" = "CrossOver.app è stata patchata con successo";
 "RestoreButtonLabel" = "Ripristina";
 "RestoreConfirm" = "Fatto!";
-"RestoreFailure" = "Questa applicazione CrossOver.app non è stata patchata o è stata patchata con una versione incompatibile di CrossOver Patcher.";
+"RestoreFailure" = "Questa applicazione CrossOver.app non è stata patchata o è stata patchata con una versione incompatibile di CXPatcher.";
 "RestoreStatusLabel" = "Ripristino di CrossOver.app";
 "RestoreSuccess" = "CrossOver.app è stata ripristinata con successo.";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@ Se incontri problemi dopo aver patchato la tua installazione, puoi scaricare una
 "DownloadGStreamer" = "Scarica GStreamer";
 "GStreamerInstalled" = "GStreamer è già installato";
 "waitFor" = "In attesa che tu legga il disclaimer e confermi";
-"confirmationValue" = "Non chiederò supporto o rimborso a Codeweavers";
-"confirmation" = "Per favore, digita 'Non chiederò supporto o rimborso a Codeweavers' nel campo di input sottostante";
+"confirmationValue" = "Non chiederò supporto o rimborso a CodeWeavers";
+"confirmation" = "Per favore, digita 'Non chiederò supporto o rimborso a CodeWeavers' nel campo di input sottostante";
 "unsupported" = "non supportatato";

--- a/Crossover patcher/ja.lproj/Localizable.strings
+++ b/Crossover patcher/ja.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "DXVKとMoltenVKのパッチを開発してくれた開発者に感謝の意を表します。彼らの素晴らしい助けとバイナリの提供に感謝します。";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "CodeWeaversダウンロードページ";
-"CrossOverPatcher" = "CrossOverパッチャー";
+"CrossOverPatcher" = "CXパッチャー";
 "CWForums" = "CodeWeaversフォーラム";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
-"CWWebsite" = "CodeWeaversはパッチされたまたは変更されたCrossoverアプリをサポートしていません。以下を参照してください";
-"CXPatcherName" = "CrossOverパッチャー";
+"CWWebsite" = "CodeWeaversはパッチされたまたは変更されたCrossOverアプリをサポートしていません。以下を参照してください";
+"CXPatcherName" = "CXパッチャー";
 "DisclaimerPleaseNoteLabelText" = "ご注意ください：";
 "DisclaimerText" = "これはCrossOverの非公式のパッチプログラムであり、CodeWeaversはその開発に一切関与していません。テストされていますが、このソフトウェアはCrossOverのインストールを使用不能または不安定にする可能性があります。自己責任で使用してください。このパッチャーの使用により、CodeWeaversの公式サポートは無効になります。
 
@@ -31,7 +31,7 @@
 "PatchStatusSuccess" = "CrossOver.appは正常にパッチが適用されました";
 "RestoreButtonLabel" = "元に戻す";
 "RestoreConfirm" = "完了！";
-"RestoreFailure" = "このCrossOver.appは未パッチであるか、CrossOver Patcherの互換性のないバージョンでパッチが適用されています。";
+"RestoreFailure" = "このCrossOver.appは未パッチであるか、CXPatcherの互換性のないバージョンでパッチが適用されています。";
 "RestoreStatusLabel" = "CrossOver.appの復元";
 "RestoreSuccess" = "CrossOver.appは正常に復元されました。";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@
 "DownloadGStreamer" = "GStreamerをダウンロード";
 "GStreamerInstalled" = "GStreamerはすでにインストールされています";
 "waitFor" = "免責事項を読んで確認するのを待っています";
-"confirmationValue" = "Codeweaversにサポートや返金を要求しないでください";
-"confirmation" = "以下の入力欄に「Codeweaversにサポートや返金を要求しないでください」と入力してください";
+"confirmationValue" = "CodeWeaversにサポートや返金を要求しないでください";
+"confirmation" = "以下の入力欄に「CodeWeaversにサポートや返金を要求しないでください」と入力してください";
 "unsupported" = "サポートされていない";

--- a/Crossover patcher/pl.lproj/Localizable.strings
+++ b/Crossover patcher/pl.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Szczególne podziękowania dla deweloperów odpowiedzialnych za łatki DXVK oraz MoltenVK za ich ogromną pomoc i udostępnienie niezbędnych plików.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "stronę pobierania CodeWeavers";
-"CrossOverPatcher" = "CrossOver Patcher";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "forum CodeWeavers";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
 "CWWebsite" = "Aby uzyskać więcej informacji, odwiedź";
-"CXPatcherName" = "CrossOver Patcher";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Uwaga:";
 "DisclaimerText" = "To jest nieoficjalny program umożliwiający łatanie programu CrossOver. CodeWeavers nie jest w żaden sposób związane z pracami i rozwojem tego programu. Pomimo przeprowadzonych testów, to oprogramowanie może spowodować, że CrossOver będzie działał w nieprawidłowy sposób. KORZYSTASZ NA WŁASNE RYZYKO. Korzystanie z tego oprogramowania narusza warunki oficjalnego wsparcia ze strony CodeWeavers.
 
@@ -31,7 +31,7 @@ Jeśli napotkasz jakiekolwiek problemy z instalacją CrossOver, możesz pobrać 
 "PatchStatusSuccess" = "CrossOver.app został załatany pomyślnie";
 "RestoreButtonLabel" = "Przywróć";
 "RestoreConfirm" = "Super!";
-"RestoreFailure" = "Ta wersja CrossOver.app jest nie załatana, lub była załatana przez nieaktualną wersję CrossOver Patcher.";
+"RestoreFailure" = "Ta wersja CrossOver.app jest nie załatana, lub była załatana przez nieaktualną wersję CXPatcher.";
 "RestoreStatusLabel" = "Przywracanie CrossOver.app";
 "RestoreSuccess" = "CrossOver.app został pomyślnie przywrócony.";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@ Jeśli napotkasz jakiekolwiek problemy z instalacją CrossOver, możesz pobrać 
 "DownloadGStreamer" = "Pobieranie Gstreamer";
 "GStreamerInstalled" = "GStreamer jest już zainstalowany";
 "waitFor" = "Czekam na przeczytanie zastrzeżenia i potwierdzenie";
-"confirmationValue" = "Nie będę prosić Codeweavers o wsparcie ani zwrot pieniędzy";
-"confirmation" =  "Wpisz 'Nie będę prosić Codeweavers o wsparcie ani zwrot pieniędzy' w polu wejściowym poniżej";
+"confirmationValue" = "Nie będę prosić CodeWeavers o wsparcie ani zwrot pieniędzy";
+"confirmation" =  "Wpisz 'Nie będę prosić CodeWeavers o wsparcie ani zwrot pieniędzy' w polu wejściowym poniżej";
 "unsupported" = "nieobsługiwany";

--- a/Crossover patcher/pt-PT.lproj/Localizable.strings
+++ b/Crossover patcher/pt-PT.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Muito obrigado aos desenvolvedores por trás dos patches DXVK e MoltenVK por sua grande ajuda e por fornecer os binários.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "Página de Downloads do CodeWeavers";
-"CrossOverPatcher" = "Patcher do CrossOver";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "Fóruns do CodeWeavers";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
-"CWWebsite" = "A Codeweavers não suporta aplicativos CrossOver modificados ou patcheados, consulte o";
-"CXPatcherName" = "Patcher do CrossOver";
+"CWWebsite" = "A CodeWeavers não suporta aplicativos CrossOver modificados ou patcheados, consulte o";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Por favor, observe:";
 "DisclaimerText" = "Este é um programa de patch não oficial para o CrossOver, e a CodeWeavers não está de forma alguma envolvida em seu desenvolvimento. Embora tenha sido testado, este software pode tornar sua instalação do CrossOver inutilizável ou instável. USE POR SUA CONTA E RISCO. O uso deste patcher também anulará qualquer suporte oficial da CodeWeavers.
 
@@ -31,7 +31,7 @@ Se você enfrentar problemas após a instalação ser patcheada, você pode baix
 "PatchStatusSuccess" = "CrossOver.app foi patcheado com sucesso";
 "RestoreButtonLabel" = "Restaurar";
 "RestoreConfirm" = "Ótimo!";
-"RestoreFailure" = "Este CrossOver.app está sem patch ou foi patcheado com uma versão incompatível do CrossOver Patcher.";
+"RestoreFailure" = "Este CrossOver.app está sem patch ou foi patcheado com uma versão incompatível do CXPatcher.";
 "RestoreStatusLabel" = "Restaurar CrossOver.app";
 "RestoreSuccess" = "CrossOver.app foi restaurado com sucesso.";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@ Se você enfrentar problemas após a instalação ser patcheada, você pode baix
 "DownloadGStreamer" = "Baixar GStreamer";
 "GStreamerInstalled" = "GStreamer já está instalado";
 "waitFor" = "Aguardando você ler o aviso legal e confirmar";
-"confirmationValue" = "Eu não solicitarei suporte ou reembolso à Codeweavers";
-"confirmation" = "Digite 'Eu não solicitarei suporte ou reembolso à Codeweavers' no campo de entrada abaixo";
+"confirmationValue" = "Eu não solicitarei suporte ou reembolso à CodeWeavers";
+"confirmation" = "Digite 'Eu não solicitarei suporte ou reembolso à CodeWeavers' no campo de entrada abaixo";
 "unsupported" = "sem suporte";

--- a/Crossover patcher/ro.lproj/Localizable.strings
+++ b/Crossover patcher/ro.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Mulțumiri multe dezvoltatorilor din spatele patch-urilor DXVK și MoltenVK pentru ajutorul lor deosebit și pentru furnizarea binarelor.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "Pagina de Descărcări CodeWeavers";
-"CrossOverPatcher" = "CrossOver Patcher";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "Forumurile CodeWeavers";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
 "CWWebsite" = "CodeWeavers nu oferă suport pentru aplicații CrossOver modificate sau patch-ate, consultați";
-"CXPatcherName" = "CrossOver Patcher";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Vă rugăm să rețineți:";
 "DisclaimerText" = "Acesta este un program de patch neoficial pentru CrossOver, iar CodeWeavers nu este în niciun fel implicată în dezvoltarea acestuia. Deși a fost testat, acest software poate face instalarea CrossOver inutilizabilă sau instabilă. FOLOSIȚI PE RISCUL PROPRIU. Utilizarea acestui patcher va anula și orice suport oficial oferit de CodeWeavers.
 
@@ -31,7 +31,7 @@ Dacă întâmpinați probleme după ce instalația a fost patch-uită, puteți d
 "PatchStatusSuccess" = "CrossOver.app a fost patch-uit cu succes";
 "RestoreButtonLabel" = "Restabilire";
 "RestoreConfirm" = "Foarte bine!";
-"RestoreFailure" = "Fie acest CrossOver.app nu are patch sau a fost patch-uit cu o versiune incompatibilă a CrossOver Patcher.";
+"RestoreFailure" = "Fie acest CrossOver.app nu are patch sau a fost patch-uit cu o versiune incompatibilă a CXPatcher.";
 "RestoreStatusLabel" = "Restabilire CrossOver.app";
 "RestoreSuccess" = "CrossOver.app a fost restabilit cu succes.";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@ Dacă întâmpinați probleme după ce instalația a fost patch-uită, puteți d
 "DownloadGStreamer" = "Descărcați GStreamer";
 "GStreamerInstalled" = "GStreamer este deja instalat";
 "waitFor" = "Așteptăm să citiți avertismentul și să confirmați";
-"confirmationValue" = "Nu voi solicita suport sau rambursare de la Codeweavers";
-"confirmation" = "Vă rugăm să tastați „Nu voi solicita suport sau rambursare de la Codeweavers” în câmpul de introducere de mai jos";
+"confirmationValue" = "Nu voi solicita suport sau rambursare de la CodeWeavers";
+"confirmation" = "Vă rugăm să tastați „Nu voi solicita suport sau rambursare de la CodeWeavers” în câmpul de introducere de mai jos";
 "unsupported" = "nesuportat";

--- a/Crossover patcher/sv.lproj/Localizable.strings
+++ b/Crossover patcher/sv.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Stort tack till utvecklarna bakom DXVK- och MoltenVK-patcharna för deras stora hjälp och för att de tillhandahåller binärerna.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "CodeWeavers nedladdningssida";
-"CrossOverPatcher" = "CrossOver Patcher";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "CodeWeavers-forum";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
 "CWWebsite" = "CodeWeavers stöder inte modifierade eller patchade CrossOver-appar, se";
-"CXPatcherName" = "CrossOver Patcher";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Observera:";
 "DisclaimerText" = "Detta är ett inofficiellt patchningsprogram för CrossOver, och CodeWeavers är inte på något sätt involverade i dess utveckling. Även om det har testats kan denna programvara göra din CrossOver-installation oanvändbar eller instabil. ANVÄND PÅ EGEN RISK. Användning av denna patcher kommer också att ogiltigförklara all officiell support från CodeWeavers.
 
@@ -31,7 +31,7 @@ Om du stöter på problem efter att din installation har blivit patchad kan du l
 "PatchStatusSuccess" = "CrossOver.app har blivit framgångsrikt patchad";
 "RestoreButtonLabel" = "Återställ";
 "RestoreConfirm" = "Bra!";
-"RestoreFailure" = "Antingen är denna CrossOver.app inte patchad eller så har den blivit patchad med en inkompatibel version av CrossOver Patcher.";
+"RestoreFailure" = "Antingen är denna CrossOver.app inte patchad eller så har den blivit patchad med en inkompatibel version av CXPatcher.";
 "RestoreStatusLabel" = "Återställ CrossOver.app";
 "RestoreSuccess" = "CrossOver.app har återställts framgångsrikt.";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@ Om du stöter på problem efter att din installation har blivit patchad kan du l
 "DownloadGStreamer" = "Ladda ner GStreamer";
 "GStreamerInstalled" = "GStreamer är redan installerat";
 "waitFor" = "Väntar på att du läser igenom friskrivningsklausulen och bekräftar";
-"confirmationValue" = "Jag kommer inte att begära support eller återbetalning från Codeweavers";
-"confirmation" = "Skriv 'Jag kommer inte att begära support eller återbetalning från Codeweavers' i inmatningsfältet nedan";
+"confirmationValue" = "Jag kommer inte att begära support eller återbetalning från CodeWeavers";
+"confirmation" = "Skriv 'Jag kommer inte att begära support eller återbetalning från CodeWeavers' i inmatningsfältet nedan";
 "unsupported" = "utan stöd";

--- a/Crossover patcher/uk.lproj/Localizable.strings
+++ b/Crossover patcher/uk.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "Велика подяка розробникам, що стоять за патчами DXVK та MoltenVK за їх велику допомогу та надання бінарних файлів.";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "Сторінка завантажень CodeWeavers";
-"CrossOverPatcher" = "Патчер CrossOver";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "Форуми CodeWeavers";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
 "CWWebsite" = "CodeWeavers не підтримує патчені або модифіковані програми CrossOver, див.";
-"CXPatcherName" = "Патчер CrossOver";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "Зверніть увагу:";
 "DisclaimerText" = "Це неофіційна програма для патчування CrossOver, і CodeWeavers не має жодної причетності до її розробки. Незважаючи на те, що вона пройшла тестування, цей софт може зробити вашу установку CrossOver непридатною або незабезпеченою. ВИКОРИСТОВУЙТЕ НА ВЛАСНИЙ РИЗИК. Використання цього патчера також анулює будь-яку офіційну підтримку від CodeWeavers.
 
@@ -31,7 +31,7 @@
 "PatchStatusSuccess" = "CrossOver.app успішно патчений";
 "RestoreButtonLabel" = "Відновити";
 "RestoreConfirm" = "Гаразд!";
-"RestoreFailure" = "Або цей CrossOver.app не патчений, або він був патчений несумісною версією CrossOver Patcher.";
+"RestoreFailure" = "Або цей CrossOver.app не патчений, або він був патчений несумісною версією CXPatcher.";
 "RestoreStatusLabel" = "Відновлення CrossOver.app";
 "RestoreSuccess" = "CrossOver.app успішно відновлено.";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@
 "DownloadGStreamer" = "Завантажити GStreamer";
 "GStreamerInstalled" = "GStreamer вже встановлено";
 "waitFor" = "Очікування, щоб ви прочитали відмову від відповідальності та підтвердження";
-"confirmationValue" = "Я не буду звертатися до Codeweavers для підтримки або повернення коштів";
-"confirmation" = "Будь ласка, введіть 'Я не буду звертатися до Codeweavers для підтримки або повернення коштів' в поле вводу нижче";
+"confirmationValue" = "Я не буду звертатися до CodeWeavers для підтримки або повернення коштів";
+"confirmation" = "Будь ласка, введіть 'Я не буду звертатися до CodeWeavers для підтримки або повернення коштів' в поле вводу нижче";
 "unsupported" = "не підтримується";

--- a/Crossover patcher/zh-Hans.lproj/Localizable.strings
+++ b/Crossover patcher/zh-Hans.lproj/Localizable.strings
@@ -6,11 +6,11 @@
 "CreditsText" = "非常感谢DXVK和MoltenVK补丁背后的开发者，他们提供了巨大的帮助和二进制文件。";
 "CrossOverDownloadURL" = "https://codeweavers.com/account/downloads";
 "CrossOverDownloadURLText" = "CodeWeavers 下载页面";
-"CrossOverPatcher" = "CrossOver 补丁程序";
+"CrossOverPatcher" = "CXPatcher";
 "CWForums" = "CodeWeavers 论坛";
 "CWForumsURL" = "https://www.codeweavers.com/support/forums/general/?t=27;msg=257865";
-"CWWebsite" = "CodeWeavers 不支持修改或打补丁的 Crossover 应用，请参阅";
-"CXPatcherName" = "CrossOver 补丁程序";
+"CWWebsite" = "CodeWeavers 不支持修改或打补丁的 CrossOver 应用，请参阅";
+"CXPatcherName" = "CXPatcher";
 "DisclaimerPleaseNoteLabelText" = "请注意：";
 "DisclaimerText" = "这是一个非官方的 CrossOver 打补丁程序，CodeWeavers 在其开发中没有任何参与。尽管经过了测试，但此软件可能会导致您的 CrossOver 安装无法使用或不稳定。请自行承担风险。使用此打补丁程序还会使您失去 CodeWeavers 的官方支持。
 
@@ -31,7 +31,7 @@
 "PatchStatusSuccess" = "已成功为 CrossOver.app 打过补丁";
 "RestoreButtonLabel" = "恢复";
 "RestoreConfirm" = "完成！";
-"RestoreFailure" = "此 CrossOver.app 未打过补丁，或者使用不兼容的 CrossOver 补丁程序版本打过补丁。";
+"RestoreFailure" = "此 CrossOver.app 未打过补丁，或者使用不兼容的 CXPatcher 版本打过补丁。";
 "RestoreStatusLabel" = "恢复 CrossOver.app";
 "RestoreSuccess" = "已成功恢复 CrossOver.app。";
 "GcenxURL" = "https://github.com/Gcenx";
@@ -40,6 +40,6 @@
 "DownloadGStreamer" = "下载 GStreamer";
 "GStreamerInstalled" = "GStreamer 已安装";
 "waitFor" = "等待您阅读免责声明并确认";
-"confirmationValue" = "我不会向 Codeweavers 请求支持或退款";
-"confirmation" = "请在下方输入框中输入“我不会向 Codeweavers 请求支持或退款”";
+"confirmationValue" = "我不会向 CodeWeavers 请求支持或退款";
+"confirmation" = "请在下方输入框中输入“我不会向 CodeWeavers 请求支持或退款”";
 "unsupported" = "不支持的";


### PR DESCRIPTION
Cleanup of translations:

Codeweavers → CodeWeavers
CrossOver Patcher → CXPatcher
crossover → CrossOver

I'm not entirely sure about the **CXPatcher** part though, was **CrossOver Patcher** meant as a pronoun? In that case, it should be changed to CXPatcher, since it is the new name for the project. Or was it meant descriptive? Like “a CrossOver Patcher”?

Since it appears in the window title, I assume, CXPatcher should be used. Here is a screenshot:

<img width="512" alt="image" src="https://github.com/italomandara/CXPatcher/assets/2091312/e843d7ba-b509-4b5c-b506-eee7e7691f4a">

