### PR TITLE
fix spelling of info.plist → Info.plist

### DIFF
--- a/Crossover patcher/Utils.swift
+++ b/Crossover patcher/Utils.swift
@@ -415,7 +415,7 @@ func parseCXPlist(plistPath: String) -> CXPlist {
 }
 
 func isCrossoverApp(url: URL, version: String? = nil, skipVersionCheck: Bool? = false) -> Bool {
-    let plistPath = url.path + "/Contents/info.plist"
+    let plistPath = url.path + "/Contents/Info.plist"
     if (f.fileExists(atPath: plistPath)) {
         let plist = parseCXPlist(plistPath: plistPath)
         if (plist.CFBundleIdentifier == "com.codeweavers.CrossOver" && skipVersionCheck == true) {


### PR DESCRIPTION
### `info.plist` → to `Info.plist` 
fixes filename search in `isCrossoverApp(url: URL, version:, skipVersionCheck:)` which caused patching to fail on case-sensitive fs failed since the actual filename is `Info.plist` *

\* totally understand that case-sensitive is probably not officially supported, but thought i would send the pr if its ok...

## discussed here

https://github.com/italomandara/CXPatcher/discussions/98