### PR TITLE
Cyberpunk 2077: DLL overrides for fully functioning CET.

### DIFF
--- a/lib/CrossOver/share/crossover/bottle_data/crossover.inf
+++ b/lib/CrossOver/share/crossover/bottle_data/crossover.inf
@@ -502,6 +502,11 @@ HKCU,"Software\Wine\AppDefaults\cxwget.exe\DllOverrides","wininet",,"builtin"
  HKCU,"Software\Wine\AppDefaults\DyinglightGame_x64_rwdi.exe\DllOverrides","*runtime_dx11",,""
 
 
+; Fix for the Cyber Engine Tweaks and RED4ext in Cyberpunk 2077 (credits: https://wiki.redmodding.org/cyber-engine-tweaks/getting-started/installing/linux-proton)
+ HKCU,"Software\Wine\AppDefaults\Cyberpunk2077.exe\DllOverrides","d3dcompiler_47",,"native,builtin"
+ HKCU,"Software\Wine\AppDefaults\Cyberpunk2077.exe\DllOverrides","version",,"native,builtin"
+ HKCU,"Software\Wine\AppDefaults\Cyberpunk2077.exe\DllOverrides","winmm",,"native,builtin"
+
 ; Make sure that winewrapper isn't hotwired with an alternative crypt32.
 HKCU,"Software\Wine\AppDefaults\winewrapper.exe\DllOverrides","crypt32",,"builtin"
 HKCU,"Software\Wine\AppDefaults\winewrapper.exe\DllOverrides","rsabase",,"builtin"


### PR DESCRIPTION
This is useful for RED4ext and Cyber Engine Tweaks to function properly under WIne.

**_Might_** need d3dcompiler_47 to install but CrossOver offers only 32bit version, which doubt has any use here.

See:
https://wiki.redmodding.org/cyber-engine-tweaks/getting-started/installing/linux-proton

![image](https://github.com/italomandara/CXPatcher/assets/47083527/2d48e5e8-0315-4ebf-b427-675f62dbf70e)
![image](https://github.com/italomandara/CXPatcher/assets/47083527/4fb29938-bde8-464a-af9c-8682118677fd)
