### PR TITLE
feat: adapt CXPatcher to CrossOver 26 layout only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build/
 *.xcuserstate
 project.xcworkspace/*
 .nova
+.codex

--- a/CROSSOVER26_PATHS.md
+++ b/CROSSOVER26_PATHS.md
@@ -1,0 +1,31 @@
+# CrossOver 26 Path Baseline
+
+This note captures the verified path differences between:
+
+- host app: `/Applications/CrossOver.app` (CrossOver 26)
+- bundled patch payload: `lib/CrossOver` (in this repository)
+
+## Verified host app info
+
+- Bundle ID: `com.codeweavers.CrossOver`
+- Version: `26.0`
+- Shared support root: `/Applications/CrossOver.app/Contents/SharedSupport/CrossOver`
+
+## Key directory mapping
+
+| Category | Bundled payload path | CrossOver 26 app path | Notes |
+| --- | --- | --- | --- |
+| GPTK root | `/lib64/apple_gpt` | `/lib64/apple_gptk` | Needs destination remap for v26 |
+| DXVK | `/lib/wine/dxvk` and `/lib64/wine/dxvk` | `/lib/dxvk` | v26 moved DXVK out of `wine` |
+| Wine tree | `/lib/wine/...` | `/lib/wine/...` | Still valid |
+| Main config | `/etc/CrossOver.conf` | `/etc/CrossOver.conf` | Still valid |
+| Metadata | `/share/crossover/bottle_data/crossover.inf` | `/share/crossover/bottle_data/crossover.inf` | Still valid |
+| Hosted app | `/CrossOver-Hosted Application/wineserver` | `/CrossOver-Hosted Application/wineserver` | Still valid |
+
+## Known compatibility hotspots
+
+1. App version check currently uses a fixed prefix and must allow 26 only.
+2. External resource copy/backup paths must target `apple_gptk` in the app.
+3. Resource list contains one malformed relative path (`lib/wine/i386-windows/wineboot.exe` missing leading slash).
+4. Backup list generation for external resources misses external root in path composition.
+5. Some legacy files may not exist in v26 and should be handled as expected missing entries.

--- a/CXPatcherTests/CrossoverCompatibilityTests.swift
+++ b/CXPatcherTests/CrossoverCompatibilityTests.swift
@@ -34,7 +34,7 @@ final class CrossoverCompatibilityTests: XCTestCase {
     }
 
     func testExternalResourcesRootTargetsAppleGptk() {
-        XCTAssertEqual(EXTERNAL_RESOURCES_ROOT, "/lib64/apple_gptk")
+        XCTAssertEqual(EXTERNAL_RESOURCES_DEST_ROOT, "/lib64/apple_gptk")
     }
 
     func testDxvkPathTargetsV26LayoutOnly() {

--- a/CXPatcherTests/CrossoverCompatibilityTests.swift
+++ b/CXPatcherTests/CrossoverCompatibilityTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import CXPatcher
+
+final class CrossoverCompatibilityTests: XCTestCase {
+    private func makeFakeCrossOverApp(version: String, bundleId: String = "com.codeweavers.CrossOver") throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let appURL = tempDir.appendingPathComponent("CrossOver.app", isDirectory: true)
+        let contentsURL = appURL.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contentsURL, withIntermediateDirectories: true)
+
+        let plist: [String: String] = [
+            "CFBundleIdentifier": bundleId,
+            "CFBundleShortVersionString": version,
+        ]
+        let plistData = try PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .xml,
+            options: 0
+        )
+        let plistURL = contentsURL.appendingPathComponent("Info.plist")
+        try plistData.write(to: plistURL)
+        return appURL
+    }
+
+    func testCrossOver26IsAccepted() throws {
+        let appURL = try makeFakeCrossOverApp(version: "26.0")
+        XCTAssertTrue(isCrossoverApp(url: appURL, skipVersionCheck: false))
+    }
+
+    func testCrossOver25IsRejected() throws {
+        let appURL = try makeFakeCrossOverApp(version: "25.0")
+        XCTAssertFalse(isCrossoverApp(url: appURL, skipVersionCheck: false))
+    }
+
+    func testExternalResourcesRootTargetsAppleGptk() {
+        XCTAssertEqual(EXTERNAL_RESOURCES_ROOT, "/lib64/apple_gptk")
+    }
+
+    func testDxvkPathTargetsV26LayoutOnly() {
+        XCTAssertTrue(WINE_RESOURCES_PATHS.contains("/lib/dxvk"))
+        XCTAssertFalse(WINE_RESOURCES_PATHS.contains("/lib/wine/dxvk"))
+        XCTAssertFalse(WINE_RESOURCES_PATHS.contains("/lib64/wine/dxvk"))
+    }
+
+    func testAllResourcePathsAreAbsolute() {
+        let nonAbsolute = WINE_RESOURCES_PATHS.filter { !$0.hasPrefix("/") }
+        XCTAssertTrue(nonAbsolute.isEmpty, "Found non-absolute paths: \(nonAbsolute)")
+    }
+}

--- a/CXPatcherTests/CrossoverCompatibilityTests.swift
+++ b/CXPatcherTests/CrossoverCompatibilityTests.swift
@@ -47,4 +47,16 @@ final class CrossoverCompatibilityTests: XCTestCase {
         let nonAbsolute = WINE_RESOURCES_PATHS.filter { !$0.hasPrefix("/") }
         XCTAssertTrue(nonAbsolute.isEmpty, "Found non-absolute paths: \(nonAbsolute)")
     }
+
+    func testInstalledCrossOver26LayoutWhenAvailable() throws {
+        let installedApp = URL(fileURLWithPath: "/Applications/CrossOver.app", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: installedApp.path) else {
+            throw XCTSkip("CrossOver.app is not installed on this machine")
+        }
+
+        XCTAssertTrue(isCrossoverApp(url: installedApp, skipVersionCheck: false))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installedApp.path + SHARED_SUPPORT_PATH + EXTERNAL_RESOURCES_DEST_ROOT))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installedApp.path + SHARED_SUPPORT_PATH + "/lib/dxvk"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installedApp.path + SHARED_SUPPORT_PATH + BOTTLE_PATH_OVERRIDE))
+    }
 }

--- a/Crossover patcher.xcodeproj/project.pbxproj
+++ b/Crossover patcher.xcodeproj/project.pbxproj
@@ -37,10 +37,23 @@
 		38F7B21D2A5DD4E100CD9511 /* IntegrateExternalsToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F7B21C2A5DD4E100CD9511 /* IntegrateExternalsToggle.swift */; };
 		38F7B21F2A5DD58600CD9511 /* SkipVersionCheckToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F7B21E2A5DD58600CD9511 /* SkipVersionCheckToggle.swift */; };
 		38F7B2212A5DD60000CD9511 /* RepatchToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F7B2202A5DD60000CD9511 /* RepatchToggle.swift */; };
+		8362869C267FDD6283DF10F7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17CB53D2D06787630F1F86C /* Cocoa.framework */; };
+		B54874C612720A540735989B /* CrossoverCompatibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B324D312C6B0C98303C3B /* CrossoverCompatibilityTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		432D200C97B59FB87138A82E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 38ACB38929D773CA00A450A0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 38ACB39029D773CA00A450A0;
+			remoteInfo = CXPatcher;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		0D9AC2C32A49F96000101F43 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2E724FF73C07F0EB2747BC09 /* CXPatcherTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CXPatcherTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		382499E32AEE946400578AA3 /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		382499E52AEE984600578AA3 /* OptionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsButton.swift; sourceTree = "<group>"; };
 		382AC3162AF8246800097003 /* AutoUpdateDisableToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoUpdateDisableToggle.swift; sourceTree = "<group>"; };
@@ -86,7 +99,20 @@
 		38FC40112A606ACB006E6A69 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		38FC40122A606AD8006E6A69 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
 		38FC40132A606BAE006E6A69 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		767B324D312C6B0C98303C3B /* CrossoverCompatibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrossoverCompatibilityTests.swift; path = CrossoverCompatibilityTests.swift; sourceTree = "<group>"; };
+		A17CB53D2D06787630F1F86C /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		55A5158F9B1F488241E72EC5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8362869C267FDD6283DF10F7 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		38ACB38829D773CA00A450A0 = {
@@ -95,6 +121,8 @@
 				3851266D2AC87E7A0067C568 /* CXPatcherDebug.entitlements */,
 				38ACB39329D773CA00A450A0 /* Crossover patcher */,
 				38ACB39229D773CA00A450A0 /* Products */,
+				CF6DAD80A2A5463EBAAC0B85 /* Frameworks */,
+				9BB3DE64614301CB2DD97667 /* CXPatcherTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -102,6 +130,7 @@
 			isa = PBXGroup;
 			children = (
 				38ACB39129D773CA00A450A0 /* CXPatcher.app */,
+				2E724FF73C07F0EB2747BC09 /* CXPatcherTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -194,6 +223,31 @@
 			path = Buttons;
 			sourceTree = "<group>";
 		};
+		9BB3DE64614301CB2DD97667 /* CXPatcherTests */ = {
+			isa = PBXGroup;
+			children = (
+				767B324D312C6B0C98303C3B /* CrossoverCompatibilityTests.swift */,
+			);
+			name = CXPatcherTests;
+			path = CXPatcherTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		B59F98196CDE740A2A176014 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				A17CB53D2D06787630F1F86C /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
+		CF6DAD80A2A5463EBAAC0B85 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B59F98196CDE740A2A176014 /* OS X */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -213,6 +267,24 @@
 			productName = "Crossover patcher";
 			productReference = 38ACB39129D773CA00A450A0 /* CXPatcher.app */;
 			productType = "com.apple.product-type.application";
+		};
+		7B7EE2EC14CFEEB4663573F8 /* CXPatcherTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9FE25DCB2F05BAD96365E056 /* Build configuration list for PBXNativeTarget "CXPatcherTests" */;
+			buildPhases = (
+				008D56B9C9AD1B34A6D27D28 /* Sources */,
+				55A5158F9B1F488241E72EC5 /* Frameworks */,
+				7C06E3841A0D216B8AA68A08 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				398EF061D258B79A96693B17 /* PBXTargetDependency */,
+			);
+			name = CXPatcherTests;
+			productName = CXPatcherTests;
+			productReference = 2E724FF73C07F0EB2747BC09 /* CXPatcherTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -254,6 +326,7 @@
 			projectRoot = "";
 			targets = (
 				38ACB39029D773CA00A450A0 /* CXPatcher */,
+				7B7EE2EC14CFEEB4663573F8 /* CXPatcherTests */,
 			);
 		};
 /* End PBXProject section */
@@ -266,6 +339,13 @@
 				0D9AC2C22A49F96000101F43 /* Localizable.strings in Resources */,
 				38EDDA382A97A73D00FF2254 /* CrossOver in Resources */,
 				38C678A229DAEF8500EB19BE /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7C06E3841A0D216B8AA68A08 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -293,6 +373,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		008D56B9C9AD1B34A6D27D28 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B54874C612720A540735989B /* CrossoverCompatibilityTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		38ACB38D29D773CA00A450A0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -328,6 +416,15 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		398EF061D258B79A96693B17 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CXPatcher;
+			target = 38ACB39029D773CA00A450A0 /* CXPatcher */;
+			targetProxy = 432D200C97B59FB87138A82E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		0D9AC2C42A49F96000101F43 /* Localizable.strings */ = {
@@ -556,6 +653,46 @@
 			};
 			name = Release;
 		};
+		9973F089EDF2CB1E95AC8DC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.italomandara.Crossover-patcher.tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CXPatcher.app/Contents/MacOS/CXPatcher";
+				TEST_TARGET_NAME = CXPatcher;
+			};
+			name = Debug;
+		};
+		DCE004B8C8E4DDDA0DBB23A3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.italomandara.Crossover-patcher.tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CXPatcher.app/Contents/MacOS/CXPatcher";
+				TEST_TARGET_NAME = CXPatcher;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -573,6 +710,15 @@
 			buildConfigurations = (
 				38ACB3A129D773CA00A450A0 /* Debug */,
 				38ACB3A229D773CA00A450A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9FE25DCB2F05BAD96365E056 /* Build configuration list for PBXNativeTarget "CXPatcherTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCE004B8C8E4DDDA0DBB23A3 /* Release */,
+				9973F089EDF2CB1E95AC8DC0 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Crossover patcher.xcodeproj/xcshareddata/xcschemes/Crossover patcher.xcscheme
+++ b/Crossover patcher.xcodeproj/xcshareddata/xcschemes/Crossover patcher.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B7EE2EC14CFEEB4663573F8"
+               BuildableName = "CXPatcherTests.xctest"
+               BlueprintName = "CXPatcherTests"
+               ReferencedContainer = "container:Crossover patcher.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Crossover patcher/Config.swift
+++ b/Crossover patcher/Config.swift
@@ -21,14 +21,15 @@ let ENABLE_RESTORE = false
 let ENABLE_REPATCH_TOGGLE = ENABLE_RESTORE
 let ENABLE_BACKUP = !ENABLE_RESTORE
 
-let SUPPORTED_CROSSOVER_VERSION = "23.7"
+let SUPPORTED_CROSSOVER_MAJOR_VERSION = 26
 let ENABLE_GSTREAMER = true
 
 let SHARED_SUPPORT_PATH = "/Contents/SharedSupport/CrossOver"
 let DEFAULT_CX_BOTTLES_PATH = "/Users/${USER}/CXPBottles"
 let LIB_PATH = "/lib/"
 
-let EXTERNAL_RESOURCES_ROOT = "/lib64/apple_gpt"
+let EXTERNAL_RESOURCES_SOURCE_ROOT = "/lib64/apple_gpt"
+let EXTERNAL_RESOURCES_DEST_ROOT = "/lib64/apple_gptk"
 let EXTERNAL_WINE_PATHS: [String] = [
     "/external",
     "/wine/x86_64-unix/atidxx64.so",
@@ -219,14 +220,11 @@ let MOLTENVK_BASELINE = "/lib64/libMoltenVK.dylib"
 
 let WINE_RESOURCES_PATHS: [String] = [
     MOLTENVK_BASELINE,
-    "/lib64/libinotify.0.dylib",
-    "/lib64/libinotify.dylib",
-    "/lib64/wine/dxvk",
-    "/lib/wine/dxvk",
+    "/lib/dxvk",
     "/lib/wine/i386-windows/kernelbase.dll",
     "/lib/wine/i386-windows/ntdll.dll",
     "/lib/wine/i386-windows/winegstreamer.dll",
-    "lib/wine/i386-windows/wineboot.exe",
+    "/lib/wine/i386-windows/wineboot.exe",
     "/lib/wine/i386-windows/winecfg.exe",
     "/lib/wine/x86_64-unix/ntdll.so",
     "/lib/wine/x86_64-unix/winegstreamer.so",
@@ -238,6 +236,10 @@ let WINE_RESOURCES_PATHS: [String] = [
     "/share/crossover/bottle_data/crossover.inf",
     "/CrossOver-Hosted Application/wineserver",
     "/share/wine/wine.inf",
+]
+
+let RESOURCE_SOURCE_OVERRIDES: [String: String] = [
+    "/lib/dxvk": "/lib/wine/dxvk",
 ]
 
 let MOLTENVK_LATEST = "/lib64/libMoltenVK-latest.dylib"

--- a/Crossover patcher/de.lproj/Localizable.strings
+++ b/Crossover patcher/de.lproj/Localizable.strings
@@ -26,7 +26,7 @@ Sollten nach dem Patchen Ihrer Installation Probleme auftreten, können Sie eine
 "InstructionsFunctionDescription" = "Dieser Patcher ändert Ihre CrossOver-Installation so, dass aktualisierte und optimierte Versionen von DXVK und MoltenVK verwendet werden, was in einigen Fällen die Kompatibilität oder Leistung einiger Spiele verbessert.";
 "InstructionsText" = "Stellen Sie sicher, dass Sie über eine unveränderte Release-Version von CrossOver verfügen, die Sie von Ihrer CodeWeavers-Kontoseite heruntergeladen haben. Stellen Sie sicher, dass CrossOver registriert und mindestens einmal ausgeführt wurde, um sicherzustellen, dass das neueste DXVK ordnungsgemäß aktiviert ist. Möglicherweise müssen Sie DXVK in CrossOver ein- und ausschalten. Sollte Ihre CrossOver-Installation aus irgendeinem Grund unbrauchbar werden, können Sie sie erneut von der CodeWeavers-Website herunterladen. Dieser Patcher nimmt keine dauerhaften Änderungen an Ihren CrossOver-Flaschen vor.";
 "PatchStatusAlreadyPatched" = "Diese CrossOver.app wurde bereits gepatcht!";
-"PatchStatusError" = "CrossOver.app konnte nicht gepatcht werden. Bitte stellen Sie sicher, dass Sie versuchen, die Release-Version von CrossOver 22 von der CodeWeavers-Website zu patchen.";
+"PatchStatusError" = "CrossOver.app konnte nicht gepatcht werden. Bitte stellen Sie sicher, dass Sie versuchen, die Release-Version von CrossOver 26 von der CodeWeavers-Website zu patchen.";
 "PatchStatusReady" = "Ziehen Sie Ihre CrossOver.app hierhin \noder klicken Sie hier, um sie im Finder auszuwählen";
 "PatchStatusSuccess" = "CrossOver.app wurde erfolgreich gepatcht";
 "RestoreButtonLabel" = "Wiederherstellen";

--- a/Crossover patcher/en.lproj/Localizable.strings
+++ b/Crossover patcher/en.lproj/Localizable.strings
@@ -26,7 +26,7 @@ If you face any issues after your installation has been patched, you may downloa
 "InstructionsFunctionDescription" = "This patcher modifies your CrossOver installation to use updated and tweaked versions of DXVK and MoltenVK, which in some instances will improve compatibility or performance for some games.";
 "InstructionsText" = "Ensure you have an unmodified release version of CrossOver, as downloaded from your CodeWeavers account page. Make sure CrossOver has been registered and run at least once, to make sure the latest DXVK is activated properly. You may need to toggle DXVK off and on within CrossOver. If for any reason your CrossOver install has been rendered unusable, it can be downloaded again from the CodeWeavers website; this patcher will not make any permanent modifications to your CrossOver bottles.";
 "PatchStatusAlreadyPatched" = "This CrossOver.app has already been patched!";
-"PatchStatusError" = "This version of CrossOver is not supported. Please use CrossOver 22 from the CodeWeavers website.";
+"PatchStatusError" = "This version of CrossOver is not supported. Please use CrossOver 26 from the CodeWeavers website.";
 "PatchStatusReady" = "Drop your CrossOver.app here \nor click to select it in Finder";
 "PatchStatusSuccess" = "CrossOver.app has been successfully patched";
 "RestoreButtonLabel" = "Restore";

--- a/Crossover patcher/es.lproj/Localizable.strings
+++ b/Crossover patcher/es.lproj/Localizable.strings
@@ -26,7 +26,7 @@ Si encuentras algún problema después de parchear CrossOver, puedes descargar u
 "InstructionsFunctionDescription" = "Este parche modifica tu instalación de CrossOver para usar versiones actualizadas y ajustadas de DXVK y MoltenVK, lo que en algunos casos mejorará la compatibilidad y/o el rendimiento para algunos juegos.";
 "InstructionsText" = "Asegúrate de tener una versión sin modificar de CrossOver descargada de la página web de CodeWeavers. Verifica que CrossOver esté registrado y se haya ejecutado al menos una vez para asegurarse de que la última versión de DXVK esté activada correctamente. Es posible que debas desactivar y volver a activar DXVK en CrossOver. Si por alguna razón tu instalación de CrossOver se vuelve inutilizable, puedes descargar nuevamente el instalador de la página web de CodeWeavers; este parche no realizará modificaciones permanentes en tus botellas de CrossOver.";
 "PatchStatusAlreadyPatched" = "¡La aplicación CrossOver.app ya ha sido parcheada!";
-"PatchStatusError" = "No se pudo parchear CrossOver.app. Por favor, verifica que estás intentando parchear la última versión de CrossOver 22 descargada del sitio web de CodeWeavers.";
+"PatchStatusError" = "No se pudo parchear CrossOver.app. Por favor, verifica que estás intentando parchear la última versión de CrossOver 26 descargada del sitio web de CodeWeavers.";
 "PatchStatusReady" = "Suelta CrossOver.app aquí \no haz clic para seleccionarlo desde Finder";
 "PatchStatusSuccess" = "¡CrossOver.app ha sido correctamente parcheada!";
 "RestoreButtonLabel" = "Restaurar";

--- a/Crossover patcher/fr.lproj/Localizable.strings
+++ b/Crossover patcher/fr.lproj/Localizable.strings
@@ -26,7 +26,7 @@ Si vous rencontrez des problèmes après avoir appliqué le patch, vous pouvez t
 "InstructionsFunctionDescription" = "Ce patch modifie votre installation de CrossOver pour utiliser des versions mises à jour et optimisées de DXVK et MoltenVK, ce qui améliorera parfois la compatibilité ou les performances pour certains jeux.";
 "InstructionsText" = "Assurez-vous d'avoir une version non modifiée de CrossOver téléchargée depuis votre page de compte CodeWeavers. Assurez-vous que CrossOver est enregistré et exécuté au moins une fois, pour vous assurer que la dernière version de DXVK est activée correctement. Vous devrez peut-être activer et désactiver DXVK dans CrossOver. Si, pour une raison quelconque, votre installation de CrossOver devient inutilisable, vous pouvez la télécharger à nouveau depuis le site web de CodeWeavers ; ce patch ne fera aucune modification permanente à vos conteneurs CrossOver.";
 "PatchStatusAlreadyPatched" = "Cette application CrossOver.app a déjà été patchée !";
-"PatchStatusError" = "Impossible de patcher CrossOver.app. Veuillez vérifier que vous tentez de patcher la version de sortie de CrossOver 22 à partir du site web de CodeWeavers.";
+"PatchStatusError" = "Impossible de patcher CrossOver.app. Veuillez vérifier que vous tentez de patcher la version de sortie de CrossOver 26 à partir du site web de CodeWeavers.";
 "PatchStatusReady" = "Déposez votre CrossOver.app ici\nou cliquez pour la sélectionner dans Finder";
 "PatchStatusSuccess" = "CrossOver.app a été correctement patchée";
 "RestoreButtonLabel" = "Restaurer";

--- a/Crossover patcher/it.lproj/Localizable.strings
+++ b/Crossover patcher/it.lproj/Localizable.strings
@@ -26,7 +26,7 @@ Se incontri problemi dopo aver patchato la tua installazione, puoi scaricare una
 "InstructionsFunctionDescription" = "Questo patcher modifica la tua installazione di CrossOver utilizzando versioni aggiornate e ottimizzate di DXVK e MoltenVK, che in alcuni casi miglioreranno la compatibilità o le prestazioni per alcuni giochi.";
 "InstructionsText" = "Assicurati di avere una versione non modificata di CrossOver, scaricata dalla pagina del tuo account CodeWeavers. Assicurati che CrossOver sia stato registrato ed eseguito almeno una volta, per assicurarti che l'ultima versione di DXVK sia attivata correttamente. Potrebbe essere necessario attivare e disattivare DXVK all'interno di CrossOver. Se per qualsiasi motivo la tua installazione di CrossOver diventa inutilizzabile, puoi scaricarla nuovamente dal sito web di CodeWeavers; questo patcher non apporterà modifiche permanenti alle tue bottiglie di CrossOver.";
 "PatchStatusAlreadyPatched" = "Questa applicazione CrossOver.app è già stata patchata!";
-"PatchStatusError" = "Impossibile applicare la patch a CrossOver.app. Verifica di stai cercando di applicare la patch alla versione ufficiale di CrossOver 22 dal sito web di CodeWeavers.";
+"PatchStatusError" = "Impossibile applicare la patch a CrossOver.app. Verifica di stai cercando di applicare la patch alla versione ufficiale di CrossOver 26 dal sito web di CodeWeavers.";
 "PatchStatusReady" = "Trascina qui la tua applicazione CrossOver.app \no fai clic per selezionarla in Finder";
 "PatchStatusSuccess" = "CrossOver.app è stata patchata con successo";
 "RestoreButtonLabel" = "Ripristina";

--- a/Crossover patcher/ja.lproj/Localizable.strings
+++ b/Crossover patcher/ja.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 "InstructionsFunctionDescription" = "このパッチャーは、CrossOverのインストールを更新および調整されたバージョンのDXVKとMoltenVKを使用するように変更します。これにより、一部のゲームの互換性やパフォーマンスが向上する場合があります。";
 "InstructionsText" = "CodeWeaversアカウントページからダウンロードした未変更のリリース版CrossOverを使用してください。最新のDXVKが正しくアクティブ化されるように、CrossOverを登録して少なくとも1回実行してください。CrossOver内でDXVKをオンとオフに切り替える必要があるかもしれません。何らかの理由でCrossOverのインストールが使用不能になった場合は、CodeWeaversのウェブサイトから再度ダウンロードすることができます。このパッチャーはCrossOverのボトルに永続的な変更を加えません。";
 "PatchStatusAlreadyPatched" = "このCrossOver.appはすでにパッチが適用されています！";
-"PatchStatusError" = "CrossOver.appのパッチを適用できませんでした。CodeWeaversのウェブサイトからリリースバージョンのCrossOver 22をパッチしようとしていることを確認してください。";
+"PatchStatusError" = "CrossOver.appのパッチを適用できませんでした。CodeWeaversのウェブサイトからリリースバージョンのCrossOver 26をパッチしようとしていることを確認してください。";
 "PatchStatusReady" = "CrossOver.appをここにドロップする\nまたはFinderで選択するためにクリックしてください";
 "PatchStatusSuccess" = "CrossOver.appは正常にパッチが適用されました";
 "RestoreButtonLabel" = "元に戻す";

--- a/Crossover patcher/pl.lproj/Localizable.strings
+++ b/Crossover patcher/pl.lproj/Localizable.strings
@@ -26,7 +26,7 @@ Jeśli napotkasz jakiekolwiek problemy z instalacją CrossOver, możesz pobrać 
 "InstructionsFunctionDescription" = "Ten program poprzez łatkę modyfikuje Twoją instalację CrossOver, aby używała zaktualizowanych i dostosowanych wersji DXVK i MoltenVK, co w niektórych przypadkach poprawia kompatybilność lub wydajność niektórych gier.";
 "InstructionsText" = "Upewnij się, że masz niezmodyfikowaną wydanie CrossOver pobraną ze strony swojego konta w CodeWeavers. Upewnij się, że CrossOver został zarejestrowany i uruchomiony przynajmniej raz, aby upewnić się, że najnowsza wersja DXVK została poprawnie aktywowana. Może być konieczne przełączenie DXVK na wyłączony i ponownie włączony w CrossOver. Jeśli z jakiegoś powodu Twoja instalacja CrossOver stała się nieużywalna, można ją ponownie pobrać ze strony internetowej CodeWeavers. Ten program łatający nie wprowadzi żadnych trwałych modyfikacji do Twoich butelek CrossOver.";
 "PatchStatusAlreadyPatched" = "Ta wersja CrossOver.app została juz wcześniej załatana!";
-"PatchStatusError" = "Nie udało się załatać CrossOver.app. Proszę upewnij się, że próbujesz załatać stabilną wersję CrossOver 22 ze strony CodeWeavers.";
+"PatchStatusError" = "Nie udało się załatać CrossOver.app. Proszę upewnij się, że próbujesz załatać stabilną wersję CrossOver 26 ze strony CodeWeavers.";
 "PatchStatusReady" = "Upuść CrossOver.app tutaj \nlub kliknij, aby ją zaznaczyć w Finderze";
 "PatchStatusSuccess" = "CrossOver.app został załatany pomyślnie";
 "RestoreButtonLabel" = "Przywróć";

--- a/Crossover patcher/pt-PT.lproj/Localizable.strings
+++ b/Crossover patcher/pt-PT.lproj/Localizable.strings
@@ -26,7 +26,7 @@ Se você enfrentar problemas após a instalação ser patcheada, você pode baix
 "InstructionsFunctionDescription" = "Este patcher modifica sua instalação do CrossOver para usar versões atualizadas e ajustadas do DXVK e MoltenVK, o que em alguns casos melhorará a compatibilidade ou desempenho para alguns jogos.";
 "InstructionsText" = "Certifique-se de ter uma versão de lançamento não modificada do CrossOver, baixada em sua página de conta da CodeWeavers. Certifique-se de que o CrossOver tenha sido registrado e executado pelo menos uma vez, para garantir que o DXVK mais recente seja ativado corretamente. Talvez seja necessário ativar e desativar o DXVK dentro do CrossOver. Se, por algum motivo, sua instalação do CrossOver ficar inutilizável, você poderá baixá-lo novamente no site da CodeWeavers; este patcher não fará modificações permanentes em seus recipientes do CrossOver.";
 "PatchStatusAlreadyPatched" = "Este CrossOver.app já foi patcheado!";
-"PatchStatusError" = "Não foi possível patchear o CrossOver.app. Verifique se você está tentando patchear a versão de lançamento do CrossOver 22 do site da CodeWeavers.";
+"PatchStatusError" = "Não foi possível patchear o CrossOver.app. Verifique se você está tentando patchear a versão de lançamento do CrossOver 26 do site da CodeWeavers.";
 "PatchStatusReady" = "Arraste seu CrossOver.app aqui \nou clique para selecioná-lo no Finder";
 "PatchStatusSuccess" = "CrossOver.app foi patcheado com sucesso";
 "RestoreButtonLabel" = "Restaurar";

--- a/Crossover patcher/ro.lproj/Localizable.strings
+++ b/Crossover patcher/ro.lproj/Localizable.strings
@@ -26,7 +26,7 @@ Dacă întâmpinați probleme după ce instalația a fost patch-uită, puteți d
 "InstructionsFunctionDescription" = "Acest patcher modifică instalarea dvs. CrossOver pentru a utiliza versiuni actualizate și ajustate ale DXVK și MoltenVK, ceea ce în unele cazuri va îmbunătăți compatibilitatea sau performanța pentru anumite jocuri.";
 "InstructionsText" = "Asigurați-vă că aveți o versiune neluată în modificare a CrossOver, descărcată de pe pagina contului dvs. CodeWeavers. Asigurați-vă că CrossOver a fost înregistrat și rulat cel puțin o dată, pentru a vă asigura că DXVK-ul cel mai recent este activat corect. S-ar putea să fie necesar să dezactivați și să reactivați DXVK în CrossOver. Dacă, din orice motiv, instalarea CrossOver devine inutilizabilă, o puteți descărca din nou de pe site-ul CodeWeavers; acest patcher nu va face modificări permanente în recipienții CrossOver.";
 "PatchStatusAlreadyPatched" = "Acest CrossOver.app a fost deja patch-uit!";
-"PatchStatusError" = "Nu s-a putut face patch-ul CrossOver.app. Vă rugăm să verificați că încercați să faceți patch la versiunea de lansare a CrossOver 22 de pe site-ul CodeWeavers.";
+"PatchStatusError" = "Nu s-a putut face patch-ul CrossOver.app. Vă rugăm să verificați că încercați să faceți patch la versiunea de lansare a CrossOver 26 de pe site-ul CodeWeavers.";
 "PatchStatusReady" = "Trageți CrossOver.app aici \nsau faceți clic pentru a-l selecta în Finder";
 "PatchStatusSuccess" = "CrossOver.app a fost patch-uit cu succes";
 "RestoreButtonLabel" = "Restabilire";

--- a/Crossover patcher/sv.lproj/Localizable.strings
+++ b/Crossover patcher/sv.lproj/Localizable.strings
@@ -26,7 +26,7 @@ Om du stöter på problem efter att din installation har blivit patchad kan du l
 "InstructionsFunctionDescription" = "Denna patcher modifierar din CrossOver-installation för att använda uppdaterade och justerade versioner av DXVK och MoltenVK, vilket i vissa fall kommer att förbättra kompatibilitet eller prestanda för vissa spel.";
 "InstructionsText" = "Se till att du har en oförändrad version av CrossOver, som har laddats ner från ditt CodeWeavers-konto. Se till att CrossOver har registrerats och körts minst en gång för att säkerställa att den senaste DXVK-versionen aktiveras korrekt. Du kan behöva slå av och på DXVK i CrossOver. Om din CrossOver-installation av någon anledning blir oanvändbar kan du ladda ner den igen från CodeWeavers webbplats; denna patcher kommer inte att göra några permanenta ändringar i dina CrossOver-flaskor.";
 "PatchStatusAlreadyPatched" = "Denna CrossOver.app har redan blivit patchad!";
-"PatchStatusError" = "Kunde inte patcha CrossOver.app. Var god kontrollera att du försöker patcha den officiella versionen av CrossOver 22 från CodeWeavers webbplats.";
+"PatchStatusError" = "Kunde inte patcha CrossOver.app. Var god kontrollera att du försöker patcha den officiella versionen av CrossOver 26 från CodeWeavers webbplats.";
 "PatchStatusReady" = "Släpp din CrossOver.app här\neller klicka för att välja den i Finder";
 "PatchStatusSuccess" = "CrossOver.app har blivit framgångsrikt patchad";
 "RestoreButtonLabel" = "Återställ";

--- a/Crossover patcher/uk.lproj/Localizable.strings
+++ b/Crossover patcher/uk.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 "InstructionsFunctionDescription" = "Цей патчер модифікує вашу установку CrossOver для використання оновлених і налаштованих версій DXVK і MoltenVK, що у деяких випадках покращує сумісність або продуктивність деяких ігор.";
 "InstructionsText" = "Переконайтеся, що у вас є незмінена версія CrossOver, завантажена зі сторінки вашого облікового запису CodeWeavers. Переконайтеся, що CrossOver зареєстрована і запущена хоча б один раз, щоб гарантувати правильне активування останньої версії DXVK. Можливо, вам доведеться вимкнути та увімкнути DXVK у CrossOver. Якщо з якихось причин ваша установка CrossOver стала непридатною, її можна завантажити знову з веб-сайту CodeWeavers; цей патчер не внесе жодних постійних змін до вашої установки CrossOver.";
 "PatchStatusAlreadyPatched" = "Цей CrossOver.app вже патчений!";
-"PatchStatusError" = "Не вдалося патчувати CrossOver.app. Будь ласка, перевірте, чи намагаєтеся ви патчувати версію випуску CrossOver 22 з веб-сайту CodeWeavers.";
+"PatchStatusError" = "Не вдалося патчувати CrossOver.app. Будь ласка, перевірте, чи намагаєтеся ви патчувати версію випуску CrossOver 26 з веб-сайту CodeWeavers.";
 "PatchStatusReady" = "Перетягніть сюди свій CrossOver.app\nабо клацніть, щоб вибрати його в Finder";
 "PatchStatusSuccess" = "CrossOver.app успішно патчений";
 "RestoreButtonLabel" = "Відновити";

--- a/Crossover patcher/zh-Hans.lproj/Localizable.strings
+++ b/Crossover patcher/zh-Hans.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 "InstructionsFunctionDescription" = "此补丁程序将修改您的 CrossOver 安装，使用更新和优化版本的 DXVK 和 MoltenVK，有时会提高某些游戏的兼容性或性能。";
 "InstructionsText" = "请确保您从 CodeWeavers 账户页面下载了未经修改的 CrossOver 发布版本。确保 CrossOver 已注册并至少运行一次，以确保最新的 DXVK 已正确启用。您可能需要在 CrossOver 中切换启用或禁用 DXVK。若有任何原因导致您的 CrossOver 无法使用，您可以从 CodeWeavers 网站重新下载它，此补丁程序不会对您的 CrossOver 容器进行任何永久性修改。";
 "PatchStatusAlreadyPatched" = "此 CrossOver.app 已经打过补丁！";
-"PatchStatusError" = "无法为该版本的 CrossOver 打补丁。请从 CodeWeavers 网站下载 CrossOver 22。";
+"PatchStatusError" = "无法为该版本的 CrossOver 打补丁。请从 CodeWeavers 网站下载 CrossOver 26。";
 "PatchStatusReady" = "将您的 CrossOver.app 拖到此处\n或点击以在访达中选择它";
 "PatchStatusSuccess" = "已成功为 CrossOver.app 打补丁";
 "RestoreButtonLabel" = "恢复";

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ For more info: [https://www.codeweavers.com/support/forums/general/?t=27;msg=257
 - CXPatcher up to 0.3 will support only 22.x.x
 - CXPatcher from 0.4 on will support 23.x.x
 - CXPatcher from 0.5 on will support 24.x.x
-- CXPatcher from 0.6 on will support 25.x.x
-and so on...
-(keep an eye on the specific version)
+- CXPatcher from 0.6 on will support 26.x.x
+Current branch support target: 26.x.x only
 
 ## What macOS does it support
 


### PR DESCRIPTION
## 变更摘要
- 仅适配 CrossOver 26（不再兼容 25），版本判定改为主版本 `26`。
- 按 CrossOver 26 目录结构修正关键路径：`apple_gptk`、`lib/dxvk`、`etc/CrossOver.conf`。
- 修复外部资源备份/恢复路径拼接、补丁流程容错与日志可读性。
- 更新 README 与多语言文案中的支持版本提示为 CrossOver 26。
- 新增/补充兼容性测试，覆盖版本识别、路径映射与已安装 26 布局检查。

## 关联任务
- `.codex/task.md`：T1~T8 均已完成（全部 `[x]`）。

## 测试结果
- `xcodebuild test -project "Crossover patcher.xcodeproj" -scheme "Crossover patcher" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
  - 结果：`** TEST SUCCEEDED **`（6 tests, 0 failures）
- `xcodebuild build -project "Crossover patcher.xcodeproj" -scheme "Crossover patcher" -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
  - 结果：`** BUILD SUCCEEDED **`

## 风险与回滚
- 风险：CrossOver 26 后续小版本目录变化可能导致路径失效。
- 缓解：关键路径集中管理 + 存在性检查 + 明确 warning/error 日志。
- 回滚：
  1. 代码层：对合并提交执行 `git revert <merge_commit>`。
  2. 运行层：使用补丁前 app 备份或 `_orig` 文件恢复。
